### PR TITLE
[tflm_modelrunner_hifi4] Add Neutron IRQ wiring in hifi4/hardware_init.c

### DIFF
--- a/_boards/mimxrt700evk/eiq_examples/tflm_modelrunner_hifi4/hifi4/hardware_init.c
+++ b/_boards/mimxrt700evk/eiq_examples/tflm_modelrunner_hifi4/hifi4/hardware_init.c
@@ -18,6 +18,14 @@
 /*${function:start}*/
 #include "fsl_debug_console.h"
 
+
+#include "fsl_inputmux_connections.h"
+#include "fsl_inputmux.h"
+
+#include <xtensa/config/core.h>
+#include <xtensa/xos.h>
+#include <xtensa/xtruntime.h>
+
 #define CORE_DCACHE_LINESIZE 64
 
 extern void xthal_dcache_region_invalidate(void *addr, size_t size);
@@ -32,14 +40,27 @@ void invalidateCacheByRange(uint32_t start_addr, uint32_t size) {
     xthal_dcache_region_invalidate((void *)start_addr, size);
 }
 
+
+volatile uint32_t * nrCTRL = (volatile uint32_t *)0x40175000U;
+volatile uint32_t * nrINTR = (volatile uint32_t *)0x40175040U;
+
+extern void Neutron_IRQHandler(void * arg);
+
 void BOARD_InitHardware(void)
 {
 
     CLOCK_SetXtalFreq(BOARD_XTAL_SYS_CLK_HZ); /* Note: need tell clock driver the frequency of OSC. */
 
     TIMER_Init();
+    INPUTMUX_Init(INPUTMUX0);
+    CLOCK_EnableClock(kCLOCK_InputMux);
+    INPUTMUX_AttachSignal(INPUTMUX0, 17U, kINPUTMUX_Neutron64IrqToDspInterrupt);
     BOARD_InitBootPins();
     BOARD_InitDebugConsole();
+
+    xos_register_interrupt_handler(DSP_INT0_SEL17_IRQn, Neutron_IRQHandler, NULL);
+    xos_interrupt_enable(DSP_INT0_SEL17_IRQn);
+
     PRINTF("DSP Init Susccessfully\r\n");
 }
 /*${function:end}*/

--- a/_boards/mimxrt700evk/eiq_examples/tflm_modelrunner_hifi4/hifi4/reconfig.cmake
+++ b/_boards/mimxrt700evk/eiq_examples/tflm_modelrunner_hifi4/hifi4/reconfig.cmake
@@ -24,6 +24,8 @@ mcux_add_xtensa_configuration(
     LD "-mlsp=${SdkRootDirPath}/${board_root}/${board}/eiq_examples/tflm_modelrunner_hifi4/hifi4/linker/min-rt"
 )
 
+include(${SdkRootDirPath}/drivers/inputmux/CMakeLists.txt)
+
 mcux_add_xtensa_configuration(
     TARGETS debug
     LD "-mlsp=${SdkRootDirPath}/${board_root}/${board}/eiq_examples/tflm_modelrunner_hifi4/hifi4/linker/gdbio"


### PR DESCRIPTION
## Summary

This PR replaces the Neutron accelerator completion polling mechanism with an interrupt-driven implementation on the HiFi4 DSP in the `tflm_modelrunner_hifi4` example for MIMXRT700-EVK.

## Changes

### `hardware_init.c`

- Added INPUTMUX headers (`fsl_inputmux.h`, `fsl_inputmux_connections.h`)
- Added Xtensa XOS headers (`xos.h`, `xtruntime.h`) for interrupt registration
- Added volatile pointers to the Neutron control and interrupt registers (`nrCTRL`, `nrINTR`)
- Updated `BOARD_InitHardware()` to:
  - Route the Neutron IRQ to DSP interrupt slot 17 using INPUTMUX (`kINPUTMUX_Neutron64IrqToDspInterrupt`)
  - Register `Neutron_IRQHandler`
  - Enable the interrupt through XOS

### `reconfig.cmake`

- Added `include(${SdkRootDirPath}/drivers/inputmux/CMakeLists.txt)` to include the INPUTMUX driver required by `hardware_init.c`

## Motivation

The previous implementation relied on polling for Neutron completion, consuming DSP cycles and preventing the core from entering low-power wait states. By switching to a hardware interrupt, the DSP can execute `waiti` and resume execution only when Neutron signals completion, improving efficiency and reducing unnecessary CPU activity.